### PR TITLE
Users can see images when browsing FB5's `/friends/` URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+on:
+  push:
+    tags:
+      - "v*"
+
+name: Release asset workflow
+
+jobs:
+  release-asset:
+    name: Release asset
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Create the archive
+        run: |
+          zip -r project.zip .* -x '*.git*' -x "*.md"
+
+      - name: Create a new release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload the asset to the release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./project.zip
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Bypass the Facebook profile picture guard and see user's profile picture in __fu
 
 ### Installation Instructions:
 
-0. Download this repository as a [ZIP file from GitHub](https://github.com/Ademking/fb-profile-picture-viewer/archive/master.zip)
-1. Unzip the file and you should have a folder named fb-profile-picture-viewer-master.
+0. Download this repository as a [ZIP file from GitHub](https://github.com/Ademking/fb-profile-picture-viewer/releases/latest/download/fb-profile-picture-viewer.zip)
+1. Unzip the file and you should have a folder named fb-profile-picture-viewer.
 2. Navigate to **chrome://extensions/** 
 3. Ensure the checkbox labeled **Developer mode** is enabled. 
 4. Click the button labeled **Load unpacked extension**
-5. Select "fb-profile-picture-viewer-master" directory.
+5. Select "fb-profile-picture-viewer" directory.
 
 ### How To Use
 

--- a/contextmenu.js
+++ b/contextmenu.js
@@ -34,7 +34,9 @@ function get_current_tab_url() {
 function get_current_username(link) {
   return new Promise((resolve, reject) => {
     const test = new URL(link);
-    if (test.pathname === "/profile.php") {
+    if (test.pathname === "/friends/") {
+      resolve(test.searchParams.get("profile_id"));
+    } else if (test.pathname === "/profile.php") {
       resolve(test.searchParams.get("id"));
     } else {
       resolve(test.pathname);


### PR DESCRIPTION
This PR contains.
- The ability to get the image when using the FB5 layout.
- Whenever a new update is pushed with a tag name, a workflow will automatically add an asset under the releases pointing to that tag. (`git tag -a v[tag-name] -m 'tag message'` && `git push origin master --tags`). And the users will be able to download the latest released `zip` file when using the `README.md`'s link.

Suggestion:
- Please remove the copyright icon from the context menu.